### PR TITLE
refactor(overlays): create dedicated unstable overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,9 @@
         alacritty-theme.overlays.default
         snowfall-frost.overlays."package/frost"
         (_final: prev: {
+          unstable = import inputs.unstable {
+            inherit (prev) system;
+          };
           ghostty = inputs.ghostty.packages.${prev.system}.default;
         })
       ];

--- a/modules/home/programs/terminal/editors/nvim/default.nix
+++ b/modules/home/programs/terminal/editors/nvim/default.nix
@@ -19,7 +19,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [ neovim ];
+    home.packages = with pkgs.unstable; [ neovim ];
     home.sessionVariables = {
       EDITOR = "nvim";
     };

--- a/overlays/neovim/default.nix
+++ b/overlays/neovim/default.nix
@@ -1,6 +1,0 @@
-{ channels, ... }:
-
-_final: _prev: {
-  inherit (channels.unstable) neovim;
-
-}


### PR DESCRIPTION
having a dedicated overlays directory was overkill considering it was just for neovim before `10.*` was on stable.